### PR TITLE
fix: include agent directory for npm install directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"repository": "",
 	"main": "dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"agent"
 	],
 	"scripts": {
 		"compile": "tsc -p ."


### PR DESCRIPTION
When install this package as dependency, the `agent` directory missing in the package directory, this patch fix it.